### PR TITLE
Test enhancement for fixtures

### DIFF
--- a/tests/SwiftAdapterTest.php
+++ b/tests/SwiftAdapterTest.php
@@ -3,13 +3,13 @@
 use GuzzleHttp\Psr7\Stream;
 use League\Flysystem\Config;
 use org\bovigo\vfs\vfsStream;
-use OpenStack\Common\Error\BadResponseError;
 use org\bovigo\vfs\content\LargeFileContent;
 use Nimbusoft\Flysystem\OpenStack\SwiftAdapter;
+use PHPUnit\Framework\TestCase;
 
-class SwiftAdapterTest extends \PHPUnit_Framework_TestCase
+class SwiftAdapterTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->config = new Config([]);
         $this->container = Mockery::mock('OpenStack\ObjectStore\v1\Models\Container');
@@ -20,7 +20,7 @@ class SwiftAdapterTest extends \PHPUnit_Framework_TestCase
         $this->root = vfsStream::setUp('home');
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         Mockery::close();
     }


### PR DESCRIPTION
# Changed log

- The `OpenStack\Common\Error\BadResponseError;` is declared, but not used. And it should be removed.
- To support latest PHPUnit version, using the `PHPUnit\Framework\TestCase` class declaration.
- According to the official [PHPUnit doc](http://www.phpunit.cn/manual/5.7/en/fixtures.html), it should use the `protected function setUp` and `protected function tearDown` methods.