### PR TITLE
PHP 8 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php-versions: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php-versions }} test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php-versions }} test
 
@@ -26,7 +26,7 @@ jobs:
         ini-values: post_max_size=256M, short_open_tag=On
         coverage: xdebug
         tools: composer
-        
+
     - name: Composer install
       run: composer install
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php-opencloud/openstack": "^3.0",
+        "php-opencloud/openstack": "^3.0 | ^3.2",
         "league/flysystem": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,12 @@
         }
     },
     "require": {
+        "php": ">=7.3",
         "php-opencloud/openstack": "^3.0 | ^3.2",
         "league/flysystem": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.5",
+        "phpunit/phpunit": "^9.0",
         "mockery/mockery": "^1.3.1",
         "mikey179/vfsstream": "^1.6.4"
     }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="true"
          verbose="true"
 >
     <testsuites>

--- a/tests/SwiftAdapterTest.php
+++ b/tests/SwiftAdapterTest.php
@@ -2,14 +2,17 @@
 
 use GuzzleHttp\Psr7\Stream;
 use League\Flysystem\Config;
-use org\bovigo\vfs\vfsStream;
-use org\bovigo\vfs\content\LargeFileContent;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Nimbusoft\Flysystem\OpenStack\SwiftAdapter;
+use org\bovigo\vfs\content\LargeFileContent;
+use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 
 class SwiftAdapterTest extends TestCase
 {
-    protected function setUp()
+    use MockeryPHPUnitIntegration;
+
+    protected function setUp(): void
     {
         $this->config = new Config([]);
         $this->container = Mockery::mock('OpenStack\ObjectStore\v1\Models\Container');
@@ -20,7 +23,7 @@ class SwiftAdapterTest extends TestCase
         $this->root = vfsStream::setUp('home');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Mockery::close();
     }


### PR DESCRIPTION
This updates the required version of `php-opencloud/openstack` so this package can be used with PHP 8.