### PR TITLE
Add content type configuration to write and writeStream

### DIFF
--- a/src/SwiftAdapter.php
+++ b/src/SwiftAdapter.php
@@ -305,7 +305,17 @@ class SwiftAdapter implements FilesystemAdapter
 
     protected function getWriteData(string $path, Config $config): array
     {
-        return ['name' => $path];
+        $data = ['name' => $path];
+
+        if ($contentType = $config->get('contentType')) {
+            $data['contentType'] = $contentType;
+        }
+
+        if ($detectContentType = $config->get('detectContentType')) {
+            $data['detectContentType'] = $detectContentType;
+        }
+
+        return $data;
     }
 
     protected function getObjectInstance(string $path): StorageObject

--- a/tests/SwiftAdapterTest.php
+++ b/tests/SwiftAdapterTest.php
@@ -283,10 +283,17 @@ class SwiftAdapterTest extends TestCase
             ->with([
                 'name' => 'hello',
                 'content' => 'world',
+                'contentType' => 'text/plain',
+                'detectContentType' => true,
             ])
             ->andReturn($this->object);
 
-        $response = $this->adapter->write('hello', 'world', $this->config);
+        $config = $this->config->extend([
+            'contentType' => 'text/plain',
+            'detectContentType' => true,
+        ]);
+
+        $response = $this->adapter->write('hello', 'world', $config);
 
         $this->assertNull($response);
     }
@@ -306,9 +313,16 @@ class SwiftAdapterTest extends TestCase
         $this->container->shouldReceive('createObject')->once()->with([
             'name' => 'hello',
             'stream' => $this->adapter->streamMock,
+            'contentType' => 'text/plain',
+            'detectContentType' => true,
         ])->andReturn($this->object);
 
-        $response = $this->adapter->writeStream('hello', $stream, $this->config);
+        $config = $this->config->extend([
+            'contentType' => 'text/plain',
+            'detectContentType' => true,
+        ]);
+
+        $response = $this->adapter->writeStream('hello', $stream, $config);
 
         $this->assertNull($response);
     }


### PR DESCRIPTION
This adds the `contentType` and `detectContentType` configuration options to `write()` and `writeStream()`.