### PR TITLE
Specify union type in phpdoc

### DIFF
--- a/src/SwiftAdapter.php
+++ b/src/SwiftAdapter.php
@@ -344,7 +344,10 @@ class SwiftAdapter implements FilesystemAdapter
         return $object;
     }
 
-    protected function normalizeObject(StorageObject $object): FileAttributes|DirectoryAttributes
+    /**
+     * @return FileAttributes|DirectoryAttributes
+     */
+    protected function normalizeObject(StorageObject $object)
     {
         $name = $this->prefixer->stripDirectoryPrefix($object->name);
 


### PR DESCRIPTION
The php version constraint for this package is PHP ^7.4 | ^8.0.
Union types are however not supported in PHP 7.4.

My suggestion is to specify the union type in the doc block for now and drop support for PHP 7.4, when it is no longer supported in a few months from now: https://www.php.net/supported-versions.php